### PR TITLE
Fix for swagger page error

### DIFF
--- a/Api/Data/ContentVersionSearchResultsInterface.php
+++ b/Api/Data/ContentVersionSearchResultsInterface.php
@@ -14,7 +14,7 @@ interface ContentVersionSearchResultsInterface extends \Magento\Framework\Api\Se
     /**
      * Get content_version list as array with identifiers as keys
      *
-     * @return array
+     * @return \Overdose\CMSContent\Api\Data\ContentVersionInterface[]
      */
     public function getItemsArray();
 


### PR DESCRIPTION
Issue: when we open http://website.com/swagger we have error "Failed to load API definition." which is caused lack of annotation. 

Reason: the object declaration is taken from annotation and we need point the precise interface.